### PR TITLE
feat: 이메일 중복 체크 분리, 회원탈퇴 전 비번 확인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.749.0",
                 "@prisma/client": "^6.3.0",
+                "axios": "^1.7.9",
                 "bcryptjs": "^2.4.3",
                 "cookie-parser": "^1.4.7",
                 "cors": "^2.8.5",
@@ -1813,12 +1814,29 @@
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
         "node_modules/aws-ssl-profiles": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
             "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
             "engines": {
                 "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.7.9",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1849,7 +1867,8 @@
         "node_modules/bcryptjs": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+            "license": "MIT"
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -2010,6 +2029,18 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
@@ -2069,6 +2100,7 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
             "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+            "license": "MIT",
             "dependencies": {
                 "cookie": "0.7.2",
                 "cookie-signature": "1.0.6"
@@ -2116,6 +2148,15 @@
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dependencies": {
                 "ms": "2.0.0"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/denque": {
@@ -2222,6 +2263,21 @@
             "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
             "dependencies": {
                 "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2360,6 +2416,41 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -2503,6 +2594,21 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2664,6 +2770,7 @@
             "version": "17.13.3",
             "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
             "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.3.0",
                 "@hapi/topo": "^5.1.0",
@@ -2687,6 +2794,7 @@
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
             "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "license": "MIT",
             "dependencies": {
                 "jws": "^3.2.2",
                 "lodash.includes": "^4.3.0",
@@ -3171,6 +3279,12 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.749.0",
         "@prisma/client": "^6.3.0",
+        "axios": "^1.7.9",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -86,3 +86,45 @@ export const handleSocialLogin = async (req, res, next) => {
     res.status(StatusCodes.BAD_REQUEST).json({ error: err.message });
   }
 };
+
+
+export const handleVerifyPassword = async (req, res, next) => {
+  try {
+    const { password } = req.body;
+    if (!password) {
+      return res.status(StatusCodes.BAD_REQUEST).json({ error: "비밀번호를 입력하세요." });
+    }
+
+    const userId = req.user.id;
+    const isValid = await userService.verifyUserPassword(userId, password);
+
+    if (!isValid) {
+      return res.status(StatusCodes.UNAUTHORIZED).json({ error: "비밀번호가 올바르지 않습니다." });
+    }
+
+    res.status(StatusCodes.OK).json({ message: "비밀번호 확인 성공" });
+  } catch (err) {
+    next(err);
+  }
+};
+
+
+
+export const handleCheckEmail = async (req, res, next) => {
+  try {
+    const { email } = req.body;
+    if (!email) {
+      return res.status(StatusCodes.BAD_REQUEST).json({ error: "이메일을 입력하세요." });
+    }
+
+    const isDuplicate = await userService.checkEmailDuplicate(email);
+
+    if (isDuplicate) {
+      return res.status(StatusCodes.CONFLICT).json({ error: "이미 사용 중인 이메일입니다." });
+    }
+
+    res.status(StatusCodes.OK).json({ message: "사용 가능한 이메일입니다." });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ import {
   handleLogoutUser,
   handleDeleteUser,
   handleSocialLogin,
+
+  handleVerifyPassword, 
+  handleCheckEmail,
 } from "./controllers/user.controller.js";
 
 import {
@@ -146,6 +149,12 @@ app.delete("/api/v1/users/delete-user", authenticateToken, handleDeleteUser);
 app.post("/api/v1/users/social-login", handleSocialLogin);
 app.get("/api/v1/users/info", authenticateToken, handleUserInfo);
 app.patch("/api/v1/users/profile/change", authenticateToken, upload.single('image'), handleProfileChange);
+
+app.post("/api/v1/users/verify-password", authenticateToken, handleVerifyPassword);
+app.post("/api/v1/users/check-email", handleCheckEmail);
+
+
+
 
 app.post("/api/v1/users/search/category", handleSearch);
 

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -37,3 +37,11 @@ export const deleteUserById = async (userId) => {
 
   return { ...user, id: user.id.toString() };
 };
+
+
+export const getUserById = async (userId) => {
+  const user = await prisma.users.findUnique({
+    where: { id: userId },
+  });
+  return user ? { ...user, id: user.id.toString() } : null;
+};

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,7 +1,7 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import dotenv from "dotenv";
-import { getUserByEmail, createUser, deleteUserById } from "../repositories/user.repository.js";
+import { getUserByEmail, getUserById, createUser, deleteUserById } from "../repositories/user.repository.js";
 
 dotenv.config();
 
@@ -78,4 +78,21 @@ export const socialLogin = async (accessToken) => {
 
 export const logoutUser = async () => {
   return { message: "로그아웃 성공" };
+};
+
+
+export const checkEmailDuplicate = async (email) => {
+  const existingUser = await getUserByEmail(email);
+  return !!existingUser; // 존재하면 true, 없으면 false 반환
+};
+
+
+export const verifyUserPassword = async (userId, password) => {
+  const user = await getUserById(userId); // 여기서 호출
+
+  if (!user) {
+    throw new Error("사용자를 찾을 수 없습니다.");
+  }
+
+  return bcrypt.compare(password, user.password);
 };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2272,6 +2272,111 @@ paths:
                     example: "인증 실패"
         500:
           description: 서버 오류
+
+
+  /api/v1/users/check-email:
+    post:
+      summary: 이메일 중복 확인
+      description: 회원가입 시 이메일이 이미 사용 중인지 확인.
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  example: "test@example.com"
+      responses:
+        200:
+          description: 사용 가능한 이메일
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "사용 가능한 이메일입니다."
+        400:
+          description: 요청 오류 (이메일 누락)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "이메일을 입력하세요."
+        409:
+          description: 이메일 중복 (이미 사용 중)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "이미 사용 중인 이메일입니다."
+        500:
+          description: 서버 오류
+
+  /api/v1/users/verify-password:
+    post:
+      summary: 비밀번호 확인
+      security:
+        - bearerAuth: [] # 인증 필요
+      description: 사용자의 비밀번호가 올바른지 검증.
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  example: "password123"
+      responses:
+        200:
+          description: 비밀번호 확인 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "비밀번호 확인 성공"
+        400:
+          description: 요청 오류 (비밀번호 누락)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "비밀번호를 입력하세요."
+        401:
+          description: 인증 실패 (잘못된 비밀번호)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "비밀번호가 올바르지 않습니다."
+        500:
+          description: 서버 오류
+
+
   /api/v1/users/social-login:
     post:
       summary: 카카오 소셜 로그인


### PR DESCRIPTION
### 📝 작업 내용 요약
1. 기존 회원가입과 같이 중복 이메일 체크했었는데
중복 이멜체크를 api다른걸로 분리해서 먼저 체크할 수 있도록하였습니다
2. 회원 탈퇴 전 비밀번호 받아서 하기 (토큰 index에 잘 추가했는지... 한번 확인 부탁드립니다

### 📋 상세 설명
작업한 내용에 대해 더 자세히 설명합니다. 예: "사용자 로그인 시 이메일 중복 검사 로직 수정", "API 응답 시간 개선을 위한 코드 최적화"


### 🙋 도움
코드 리뷰, 추가 정보 또는 테스트가 필요한 부분을 언급하거나 동료에게 도움을 요청합니다. 예: "리뷰 부탁드립니다", "테스트 환경에서 확인 필요"

